### PR TITLE
[KARAF-1842] Implemented Service Tracker to remove unavailable distributed service.

### DIFF
--- a/dosgi/src/main/java/org/apache/karaf/cellar/dosgi/ServiceTracker.java
+++ b/dosgi/src/main/java/org/apache/karaf/cellar/dosgi/ServiceTracker.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.cellar.dosgi;
+
+import org.apache.karaf.cellar.core.ClusterManager;
+import org.apache.karaf.cellar.core.Node;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Listener called when a new service is exported.
+ */
+public class ServiceTracker implements Runnable {
+
+    private static final transient Logger LOGGER = LoggerFactory.getLogger(ServiceTracker.class);
+
+    private ClusterManager clusterManager;
+
+    private Map<String, EndpointDescription> remoteEndpoints;
+
+    private ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    
+    public void init() {
+        LOGGER.info("CELLAR SERVICE TRACKER: a new Task initialized");
+        remoteEndpoints = clusterManager.getMap(Constants.REMOTE_ENDPOINTS);
+        scheduler.scheduleWithFixedDelay(this, 10, 10, TimeUnit.SECONDS);
+    }
+
+    public void destroy() {
+        LOGGER.info("CELLAR SERVICE TRACKER: task is being destroyed");
+        scheduler.shutdown();
+    }
+
+    public ClusterManager getClusterManager() {
+        return clusterManager;
+    }
+
+    public void setClusterManager(ClusterManager clusterManager) {
+        this.clusterManager = clusterManager;
+    }
+
+
+    @Override
+    public void run() {
+        LOGGER.trace("SERVICE TRACKER: running the service tracker task");
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            if (!remoteEndpoints.isEmpty()) {
+                LOGGER.trace("SERVICE TRACKER: Founded {} remote endpoints", remoteEndpoints.size());
+                Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+                final Set<Node> activeNodes = clusterManager.listNodes();
+                
+                // create a clone of remote endpoint to avoid concurrency concerns while iterating it
+                final Set<Map.Entry<String, EndpointDescription>> list = new HashSet<Map.Entry<String, EndpointDescription>>(remoteEndpoints.entrySet());
+                
+                for (Map.Entry<String, EndpointDescription> entry : list) {
+                    final EndpointDescription endpointDescription = entry.getValue();
+                    final String key = entry.getKey();
+                    
+                    // create a clone of nodes to avoid concurrency concerns while iterating it
+                    final Set<Node> nodes = new HashSet<Node>(endpointDescription.getNodes());
+                    
+                    boolean endpointChanged = false;
+                    for(Node n : nodes) {
+                        if(!activeNodes.contains(n)) {
+                            LOGGER.debug("SERVICE TRACKER: Removing node with id {} since it is not active", n.getId());
+                            endpointDescription.getNodes().remove(n);
+                            endpointChanged = true;                        
+                        }
+                    }
+
+                    if(endpointChanged) {
+                        // if the endpoint is used for export from other nodes too, then update it
+                        if (endpointDescription.getNodes().size() > 0) {
+                            LOGGER.debug("SERVICE TRACKER: Updating remote endpoint {}", key);
+                            remoteEndpoints.put(key, endpointDescription);
+                        } else { // remove endpoint permanently
+                            LOGGER.debug("SERVICE TRACKER: Removing remote endpoint {}", key);
+                            remoteEndpoints.remove(key);
+                        }
+                    } 
+                }
+            } else {
+                LOGGER.debug("SERVICE TRACKER: no remote endpoints found");
+            }
+        } catch (Exception e) {
+            LOGGER.error("SERVICE TRACKER: failed to run service tracker task",e);
+        } finally {
+           Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+  
+}

--- a/dosgi/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/dosgi/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -55,4 +55,8 @@
     <reference id="commandStore" interface="org.apache.karaf.cellar.core.command.CommandStore"/>
     <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
 
+
+    <bean id="serviceTracker" class="org.apache.karaf.cellar.dosgi.ServiceTracker" init-method="init" destroy-method="destroy">
+        <property name="clusterManager" ref="clusterManager"/>
+    </bean>
 </blueprint>

--- a/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/HazelcastClusterManager.java
+++ b/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/HazelcastClusterManager.java
@@ -87,7 +87,7 @@ public class HazelcastClusterManager extends HazelcastInstanceAware implements C
             Set<Member> members = cluster.getMembers();
             if (members != null && !members.isEmpty()) {
                 for (Member member : members) {
-                    HazelcastNode node = new HazelcastNode(member.getInetSocketAddress().getHostName(), member.getInetSocketAddress().getPort());
+                    HazelcastNode node = new HazelcastNode(member.getSocketAddress().getHostString(), member.getSocketAddress().getPort());
                     nodes.add(node);
                 }
             }
@@ -110,7 +110,7 @@ public class HazelcastClusterManager extends HazelcastInstanceAware implements C
                 Set<Member> members = cluster.getMembers();
                 if (members != null && !members.isEmpty()) {
                     for (Member member : members) {
-                        HazelcastNode node = new HazelcastNode(member.getInetSocketAddress().getHostName(), member.getInetSocketAddress().getPort());
+                        HazelcastNode node = new HazelcastNode(member.getSocketAddress().getHostString(), member.getSocketAddress().getPort());
                         if (ids.contains(node.getId())) {
                             nodes.add(node);
                         }
@@ -135,7 +135,7 @@ public class HazelcastClusterManager extends HazelcastInstanceAware implements C
                 Set<Member> members = cluster.getMembers();
                 if (members != null && !members.isEmpty()) {
                     for (Member member : members) {
-                        HazelcastNode node = new HazelcastNode(member.getInetSocketAddress().getHostName(), member.getInetSocketAddress().getPort());
+                        HazelcastNode node = new HazelcastNode(member.getSocketAddress().getHostString(), member.getSocketAddress().getPort());
                         if (id.equals(node.getId())) {
                             return node;
                         }

--- a/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/HazelcastGroupManager.java
+++ b/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/HazelcastGroupManager.java
@@ -140,7 +140,7 @@ public class HazelcastGroupManager implements GroupManager, EntryListener, Confi
             Cluster cluster = instance.getCluster();
             if (cluster != null) {
                 Member member = cluster.getLocalMember();
-                node = new HazelcastNode(member.getInetSocketAddress().getHostName(), member.getInetSocketAddress().getPort());
+                node = new HazelcastNode(member.getSocketAddress().getHostString(), member.getSocketAddress().getPort());
             }
             return node;
         } finally {

--- a/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/HazelcastInstanceAware.java
+++ b/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/HazelcastInstanceAware.java
@@ -42,7 +42,7 @@ public class HazelcastInstanceAware {
         Cluster cluster = instance.getCluster();
         if (cluster != null) {
             Member member = cluster.getLocalMember();
-            return new HazelcastNode(member.getInetSocketAddress().getHostName(), member.getInetSocketAddress().getPort());
+            return new HazelcastNode(member.getSocketAddress().getHostString(), member.getSocketAddress().getPort());
         } else {
             return null;
         }


### PR DESCRIPTION
In this PR, it was implemented a Service Tracker to remove unavailable distributed services from the list of available endpoints. It was implemented taking DiscoveryTask as a reference.

###### Modifications in `org/apache/karaf/cellar/hazelcast/HazelcastClusterManager`, `org/apache/karaf/cellar/hazelcast/HazelcastGroupManager` and `org/apache/karaf/cellar/hazelcast/HazelcastInstanceAware`
In Hazelcast Cellar bundle updates `getInetSocketAddress().getHostName()` to `getSocketAddress().getHostString()` when populating cellar nodes since `getHostName()` "may trigger a name service reverse lookup if the address was created with a literal IP address". It leads to different node IDs depending if node is running locally  (it will reverse loockup) or not (it will not reverse lockup). Thus, it is impossible to compare between remote endpoint node IDs (`endpointDescription.getNodes()`) and cluster manager node IDs (`clusterManager.listNodes()`).

###### Modifications in `org/apache/karaf/cellar/hazelcast/HazelcastClusterManager`
`org/apache/karaf/cellar/hazelcast/QueueConsumer.run` could throw exceptions like OperationTimeoutException. This could lead to QueueConsumer task being killed making the karaf container useless since it couldn't communicate. Therefore, when calling `getQueue().poll(10, TimeUnit.SECONDS)` it now catches all possible Exception to ensure that QueueConsumer task never dies.

All this changes are needed in order to Service Tracker to work.