### PR TITLE
Avoid reverse DNS lookups if cluster member hostname is literal IP address

### DIFF
--- a/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/HazelcastClusterManager.java
+++ b/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/HazelcastClusterManager.java
@@ -87,7 +87,7 @@ public class HazelcastClusterManager extends HazelcastInstanceAware implements C
             Set<Member> members = cluster.getMembers();
             if (members != null && !members.isEmpty()) {
                 for (Member member : members) {
-                    HazelcastNode node = new HazelcastNode(member.getInetSocketAddress().getHostName(), member.getInetSocketAddress().getPort());
+                    HazelcastNode node = new HazelcastNode(member);
                     nodes.add(node);
                 }
             }
@@ -110,7 +110,7 @@ public class HazelcastClusterManager extends HazelcastInstanceAware implements C
                 Set<Member> members = cluster.getMembers();
                 if (members != null && !members.isEmpty()) {
                     for (Member member : members) {
-                        HazelcastNode node = new HazelcastNode(member.getInetSocketAddress().getHostName(), member.getInetSocketAddress().getPort());
+                        HazelcastNode node = new HazelcastNode(member);
                         if (ids.contains(node.getId())) {
                             nodes.add(node);
                         }
@@ -135,7 +135,7 @@ public class HazelcastClusterManager extends HazelcastInstanceAware implements C
                 Set<Member> members = cluster.getMembers();
                 if (members != null && !members.isEmpty()) {
                     for (Member member : members) {
-                        HazelcastNode node = new HazelcastNode(member.getInetSocketAddress().getHostName(), member.getInetSocketAddress().getPort());
+                        HazelcastNode node = new HazelcastNode(member);
                         if (id.equals(node.getId())) {
                             return node;
                         }

--- a/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/HazelcastGroupManager.java
+++ b/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/HazelcastGroupManager.java
@@ -140,7 +140,7 @@ public class HazelcastGroupManager implements GroupManager, EntryListener, Confi
             Cluster cluster = instance.getCluster();
             if (cluster != null) {
                 Member member = cluster.getLocalMember();
-                node = new HazelcastNode(member.getInetSocketAddress().getHostName(), member.getInetSocketAddress().getPort());
+                node = new HazelcastNode(member);
             }
             return node;
         } finally {

--- a/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/HazelcastInstanceAware.java
+++ b/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/HazelcastInstanceAware.java
@@ -42,7 +42,7 @@ public class HazelcastInstanceAware {
         Cluster cluster = instance.getCluster();
         if (cluster != null) {
             Member member = cluster.getLocalMember();
-            return new HazelcastNode(member.getInetSocketAddress().getHostName(), member.getInetSocketAddress().getPort());
+            return new HazelcastNode(member);
         } else {
             return null;
         }

--- a/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/HazelcastNode.java
+++ b/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/HazelcastNode.java
@@ -13,7 +13,12 @@
  */
 package org.apache.karaf.cellar.hazelcast;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
 import org.apache.karaf.cellar.core.Node;
+
+import com.hazelcast.core.Member;
 
 /**
  * Cluster node powered by Hazelcast.
@@ -25,11 +30,17 @@ public class HazelcastNode implements Node {
     private String host;
     private int port;
 
-    public HazelcastNode(String host, int port) {
+    public HazelcastNode(Member member) {
+        InetSocketAddress addr = member.getSocketAddress();
+        this.host = getHostString(addr);
+        this.port = addr.getPort();
         StringBuilder builder = new StringBuilder();
-        this.host = host;
-        this.port = port;
         this.id = builder.append(host).append(":").append(port).toString();
+    }
+
+    static String getHostString(InetSocketAddress socketAddr) {
+      InetAddress addr = socketAddr.getAddress();
+      return (addr != null && addr.toString().startsWith("/")) ? addr.getHostAddress() : socketAddr.getHostName();
     }
 
     @Override
@@ -83,5 +94,5 @@ public class HazelcastNode implements Node {
 		return "HazelcastNode [id=" + id + ", host=" + host + ", port=" + port
 				+ "]";
 	}
-    
+
 }


### PR DESCRIPTION
Now, Cellar `HazelcastNode` class constructor uses `member.getInetSocketAddress().getHostName()` for host name and ID. As noted in `InetSocketAddress` class docs, `getHostName()` method may trigger a name service reverse lookup if the address was created with a literal IP address. In some environments (like Kubernetes) this lead to problem with nodes identification because no cluster-wide DNS or PTR records are available for reverse lookups, but local IP could be resolvable using /etc/hostname file provided by cluster manager.

In proposed patch, if member address was created with a literal IP address, `getHostName()` method is not called and IP address string representation is used as member host name.

Ideally, we should use `InetSocketAddress.getHostString()` method, but it is available only since Java 1.7, so in 1.6 only way to get host identity without reverse DNS lookups is rather ugly set of checks involving output of `InetSocketAddress.toString()`.