### PR TITLE
Fix for discovered members property name

### DIFF
--- a/core/src/main/java/org/apache/karaf/cellar/core/discovery/Discovery.java
+++ b/core/src/main/java/org/apache/karaf/cellar/core/discovery/Discovery.java
@@ -19,7 +19,6 @@ package org.apache.karaf.cellar.core.discovery;
 public class Discovery {
 
     public static final String PID = "org.apache.karaf.cellar.discovery";
-    public static final String MEMBERS_PROPERTY_NAME = "tcpIpMembers";
     public static final String DISCOVERED_MEMBERS_PROPERTY_NAME = "discoveredMembers";
 
     public static final String INTERVAL = "interval";

--- a/core/src/main/java/org/apache/karaf/cellar/core/discovery/DiscoveryTask.java
+++ b/core/src/main/java/org/apache/karaf/cellar/core/discovery/DiscoveryTask.java
@@ -70,7 +70,7 @@ public class DiscoveryTask implements Runnable {
                     	properties = new Hashtable();
                     }
                     String newMemberText = CellarUtils.createStringFromSet(members, true);
-                    String memberText = (String) properties.get(Discovery.MEMBERS_PROPERTY_NAME);
+                    String memberText = (String) properties.get(Discovery.DISCOVERED_MEMBERS_PROPERTY_NAME);
                     if (newMemberText != null && newMemberText.length() > 0 && !newMemberText.equals(memberText)) {
                         properties.put(Discovery.DISCOVERED_MEMBERS_PROPERTY_NAME, newMemberText);
                         LOGGER.trace("CELLAR DISCOVERY: adding a new member {} to configuration and updating it", newMemberText);


### PR DESCRIPTION
Currently `DiscoveryTask` performs checking and storing of discovered members using different property names, so configuration is continously updated regardless of member list changing. This patch fixes this behaviour.