### PR TITLE
KARAF-4538 - fixed pattern matching for the bundle symbolic name of bundles, matching the nameId

### DIFF
--- a/bundle/src/main/java/org/apache/karaf/cellar/bundle/management/internal/CellarBundleMBeanImpl.java
+++ b/bundle/src/main/java/org/apache/karaf/cellar/bundle/management/internal/CellarBundleMBeanImpl.java
@@ -516,14 +516,14 @@ public class CellarBundleMBeanImpl extends StandardMBean implements CellarBundle
                             bundles.add(bundle);
                         } else {
                             // no match on bundle name, fall back to symbolic name and check if it matches the regex
-                            matcher = namePattern.matcher(name);
+                            matcher = namePattern.matcher(bundleSplit[0]);
                             if (matcher.find()) {
                                 bundles.add(bundle);
                             }
                         }
                     } else {
                         // no bundle name, fall back to symbolic name and check if it matches the regex
-                        matcher = namePattern.matcher(name);
+                        matcher = namePattern.matcher(bundleSplit[0]);
                         if (matcher.find()) {
                             bundles.add(bundle);
                         }

--- a/bundle/src/main/java/org/apache/karaf/cellar/bundle/shell/BundleCommandSupport.java
+++ b/bundle/src/main/java/org/apache/karaf/cellar/bundle/shell/BundleCommandSupport.java
@@ -122,14 +122,14 @@ public abstract class BundleCommandSupport extends CellarCommandSupport {
                             bundles.add(bundle);
                         } else {
                             // no match on bundle name, fall back to symbolic name and check if it matches the regex
-                            matcher = namePattern.matcher(name);
+                            matcher = namePattern.matcher(bundleSplit[0]);
                             if (matcher.find()) {
                                 bundles.add(bundle);
                             }
                         }
                     } else {
                         // no bundle name, fall back to symbolic name and check if it matches the regex
-                        matcher = namePattern.matcher(name);
+                        matcher = namePattern.matcher(bundleSplit[0]);
                         if (matcher.find()) {
                             bundles.add(bundle);
                         }


### PR DESCRIPTION
There was a small mistake in the pattern matching code for "collecting" the bundles, matching nameId.
The pattern was checked against the same string, in case the version of the searched bundles matches the target.