### PR TITLE
Fix memory leak in BasicCommandStore

### DIFF
--- a/core/src/main/java/org/apache/karaf/cellar/core/command/ResultHandler.java
+++ b/core/src/main/java/org/apache/karaf/cellar/core/command/ResultHandler.java
@@ -37,7 +37,7 @@ public class ResultHandler<R extends Result> implements EventHandler<R> {
     public void handle(R result) {
         if (commandStore != null && commandStore.getPending() != null) {
             String id = result.getId();
-            Command command = commandStore.getPending().get(id);
+            Command command = commandStore.getPending().remove(id);
 
             if (command != null && handlerSwitch.getStatus().equals(SwitchStatus.ON)) {
                 command.addResults(result);

--- a/core/src/main/java/org/apache/karaf/cellar/core/command/TimeoutTask.java
+++ b/core/src/main/java/org/apache/karaf/cellar/core/command/TimeoutTask.java
@@ -31,11 +31,8 @@ public class TimeoutTask implements Runnable {
      */
     @Override
     public void run() {
-        // check if command is still pending
-        Boolean pending = store.getPending().containsKey(command.getId());
-        if (pending) {
-            store.getPending().remove(command.getId());
-        }
+        // remove command if it is still pending
+        store.getPending().remove(command.getId());
     }
 
 }


### PR DESCRIPTION
Currently scheduled commands are not removed from BasicCommandStore upon executing, so memory leak is introduced. This patch fixes memory leak and also simplifies command scheduling and timeout handling code.