### PR TITLE
KARAF-4698 - proper handling of uninstalling bundle in cluster when one of the nodes is offline

### DIFF
--- a/bundle/src/main/java/org/apache/karaf/cellar/bundle/BundleSynchronizer.java
+++ b/bundle/src/main/java/org/apache/karaf/cellar/bundle/BundleSynchronizer.java
@@ -144,6 +144,13 @@ public class BundleSynchronizer extends BundleSupport implements Synchronizer {
                                         } else {
                                             LOGGER.debug("CELLAR BUNDLE: bundle located {} already started on node", state.getLocation());
                                         }
+                                    } else if (state.getStatus() == Bundle.UNINSTALLED) {
+                                        if (isInstalled(state.getLocation())) {
+                                            LOGGER.debug("CELLAR BUNDLE: uninstalling bundle {}/{} on node", symbolicName, version);
+                                            uninstallBundle(symbolicName, version);
+                                        } else {
+                                            LOGGER.debug("CELLAR BUNDLE: bundle {}/{} already uninstalled on node", symbolicName, version);
+                                        }
                                     }
                                 } catch (BundleException e) {
                                     LOGGER.error("CELLAR BUNDLE: failed to pull bundle {}", id, e);

--- a/bundle/src/main/java/org/apache/karaf/cellar/bundle/management/internal/CellarBundleMBeanImpl.java
+++ b/bundle/src/main/java/org/apache/karaf/cellar/bundle/management/internal/CellarBundleMBeanImpl.java
@@ -207,7 +207,8 @@ public class CellarBundleMBeanImpl extends StandardMBean implements CellarBundle
                 }
 
                 // update the cluster state
-                clusterBundles.remove(bundle);
+                state.setStatus(Bundle.UNINSTALLED);
+                clusterBundles.put(bundle, state);
 
                 // broadcast the cluster event
                 String[] split = bundle.split("/");

--- a/bundle/src/main/java/org/apache/karaf/cellar/bundle/shell/UninstallBundleCommand.java
+++ b/bundle/src/main/java/org/apache/karaf/cellar/bundle/shell/UninstallBundleCommand.java
@@ -78,7 +78,9 @@ public class UninstallBundleCommand extends BundleCommandSupport {
                     return null;
                 }
 
-                clusterBundles.remove(bundle);
+                // update the cluster state
+                state.setStatus(Bundle.UNINSTALLED);
+                clusterBundles.put(bundle, state);
 
                 // broadcast the cluster event
                 String[] split = bundle.split("/");


### PR DESCRIPTION
Ticket: https://issues.apache.org/jira/browse/KARAF-4698
Resolution: now the bundle state is not removed from the cluster map on uninstall, but rather updated with the state Bundle.UNINSTALLED. The BundleSynchronizer is also handling that state properly on cluster pull