### PR TITLE
KARAF-4538 - use matches() instead of find() to make bundle matching strategy more predictable

### DIFF
--- a/bundle/src/main/java/org/apache/karaf/cellar/bundle/management/internal/CellarBundleMBeanImpl.java
+++ b/bundle/src/main/java/org/apache/karaf/cellar/bundle/management/internal/CellarBundleMBeanImpl.java
@@ -472,7 +472,7 @@ public class CellarBundleMBeanImpl extends StandardMBean implements CellarBundle
         // id is a number
         Pattern pattern = Pattern.compile("^\\d+$");
         Matcher matcher = pattern.matcher(nameId);
-        if (matcher.find()) {
+        if (matcher.matches()) {
             int idInt = Integer.parseInt(nameId);
             for (String bundle : clusterBundles.keySet()) {
                 if (clusterBundles.get(bundle).getId() == idInt) {
@@ -486,7 +486,7 @@ public class CellarBundleMBeanImpl extends StandardMBean implements CellarBundle
         // id as a number range
         pattern = Pattern.compile("^(\\d+)-(\\d+)$");
         matcher = pattern.matcher(nameId);
-        if (matcher.find()) {
+        if (matcher.matches()) {
             int index = nameId.indexOf('-');
             long startId = Long.parseLong(nameId.substring(0, index));
             long endId = Long.parseLong(nameId.substring(index + 1));
@@ -517,19 +517,19 @@ public class CellarBundleMBeanImpl extends StandardMBean implements CellarBundle
                     if (state.getName() != null) {
                         // bundle name is populated, check if it matches the regex
                         matcher = namePattern.matcher(state.getName());
-                        if (matcher.find()) {
+                        if (matcher.matches()) {
                             bundles.add(bundle);
                         } else {
                             // no match on bundle name, fall back to symbolic name and check if it matches the regex
                             matcher = namePattern.matcher(bundleSplit[0]);
-                            if (matcher.find()) {
+                            if (matcher.matches()) {
                                 bundles.add(bundle);
                             }
                         }
                     } else {
                         // no bundle name, fall back to symbolic name and check if it matches the regex
                         matcher = namePattern.matcher(bundleSplit[0]);
-                        if (matcher.find()) {
+                        if (matcher.matches()) {
                             bundles.add(bundle);
                         }
                     }
@@ -547,19 +547,19 @@ public class CellarBundleMBeanImpl extends StandardMBean implements CellarBundle
             if (state.getName() != null) {
                 // bundle name is populated, check if it matches the regex
                 matcher = namePattern.matcher(state.getName());
-                if (matcher.find()) {
+                if (matcher.matches()) {
                     bundles.add(bundle);
                 } else {
                     // no match on bundle name, fall back to symbolic name and check if it matches the regex
                     matcher = namePattern.matcher(bundle);
-                    if (matcher.find()) {
+                    if (matcher.matches()) {
                         bundles.add(bundle);
                     }
                 }
             } else {
                 // no bundle name, fall back to symbolic name and check if it matches the regex
                 matcher = namePattern.matcher(bundle);
-                if (matcher.find()) {
+                if (matcher.matches()) {
                     bundles.add(bundle);
                 }
             }

--- a/bundle/src/main/java/org/apache/karaf/cellar/bundle/shell/BundleCommandSupport.java
+++ b/bundle/src/main/java/org/apache/karaf/cellar/bundle/shell/BundleCommandSupport.java
@@ -73,7 +73,7 @@ public abstract class BundleCommandSupport extends CellarCommandSupport {
         // id is a number
         Pattern pattern = Pattern.compile("^\\d+$");
         Matcher matcher = pattern.matcher(nameId);
-        if (matcher.find()) {
+        if (matcher.matches()) {
             int id = Integer.parseInt(nameId);
             for (String bundle : clusterBundles.keySet()) {
                 if (clusterBundles.get(bundle).getId() == id) {
@@ -87,7 +87,7 @@ public abstract class BundleCommandSupport extends CellarCommandSupport {
         // id as a number range
         pattern = Pattern.compile("^(\\d+)-(\\d+)$");
         matcher = pattern.matcher(nameId);
-        if (matcher.find()) {
+        if (matcher.matches()) {
             int index = nameId.indexOf('-');
             long startId = Long.parseLong(nameId.substring(0, index));
             long endId = Long.parseLong(nameId.substring(index + 1));
@@ -118,19 +118,19 @@ public abstract class BundleCommandSupport extends CellarCommandSupport {
                     if (state.getName() != null) {
                         // bundle name is populated, check if it matches the regex
                         matcher = namePattern.matcher(state.getName());
-                        if (matcher.find()) {
+                        if (matcher.matches()) {
                             bundles.add(bundle);
                         } else {
                             // no match on bundle name, fall back to symbolic name and check if it matches the regex
                             matcher = namePattern.matcher(bundleSplit[0]);
-                            if (matcher.find()) {
+                            if (matcher.matches()) {
                                 bundles.add(bundle);
                             }
                         }
                     } else {
                         // no bundle name, fall back to symbolic name and check if it matches the regex
                         matcher = namePattern.matcher(bundleSplit[0]);
-                        if (matcher.find()) {
+                        if (matcher.matches()) {
                             bundles.add(bundle);
                         }
                     }
@@ -148,19 +148,19 @@ public abstract class BundleCommandSupport extends CellarCommandSupport {
             if (state.getName() != null) {
                 // bundle name is populated, check if it matches the regex
                 matcher = namePattern.matcher(state.getName());
-                if (matcher.find()) {
+                if (matcher.matches()) {
                     bundles.add(bundle);
                 } else {
                     // no match on bundle name, fall back to symbolic name and check if it matches the regex
                     matcher = namePattern.matcher(bundle);
-                    if (matcher.find()) {
+                    if (matcher.matches()) {
                         bundles.add(bundle);
                     }
                 }
             } else {
                 // no bundle name, fall back to symbolic name and check if it matches the regex
                 matcher = namePattern.matcher(bundle);
-                if (matcher.find()) {
+                if (matcher.matches()) {
                     bundles.add(bundle);
                 }
             }


### PR DESCRIPTION
The fix makes bundle selection more predictable as otherwise "cluster:bundle-start default dx" command is applied to all my bundles, whose name starts with "dx" (e.g. dx-core, dx-ext, dx-provider, etc.), which is not in line with how the org.apache.karaf.bundle.core.internal.BundleSelectorImpl is doing matching.