### PR TITLE
KARAF-4708 - Cellar: stopped bundle state (Resolved) is not pulled from cluster by ByndleSynchronizer

### DIFF
--- a/bundle/src/main/java/org/apache/karaf/cellar/bundle/BundleSupport.java
+++ b/bundle/src/main/java/org/apache/karaf/cellar/bundle/BundleSupport.java
@@ -43,13 +43,7 @@ public class BundleSupport extends CellarSupport {
     }
 
     public boolean isInstalled(String location) {
-        Bundle[] bundles = getBundleContext().getBundles();
-        for (Bundle bundle : bundles) {
-            if (bundle.getLocation().equals(location)) {
-                return true;
-            }
-        }
-        return false;
+        return findBundle(location) != null;
     }
 
     public boolean isStarted(String location) {
@@ -172,5 +166,22 @@ public class BundleSupport extends CellarSupport {
 	public void setFeaturesService(FeaturesService featureService) {
 		this.featuresService = featureService;
 	}
+
+    /**
+     * Finds locally installed bundle by its location.
+     * 
+     * @param location
+     *            the location of the bundle to be found
+     * @return locally installed bundle for the specified location or <code>null</code> if there is no matching bundle installed
+     */
+    protected Bundle findBundle(String location) {
+        Bundle[] bundles = getBundleContext().getBundles();
+        for (Bundle bundle : bundles) {
+            if (bundle.getLocation().equals(location)) {
+                return bundle;
+            }
+        }
+        return null;
+    }
 
 }

--- a/bundle/src/main/java/org/apache/karaf/cellar/bundle/BundleSynchronizer.java
+++ b/bundle/src/main/java/org/apache/karaf/cellar/bundle/BundleSynchronizer.java
@@ -24,12 +24,14 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.BundleReference;
+import org.osgi.framework.wiring.FrameworkWiring;
 import org.osgi.service.cm.Configuration;
 import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Map;
 import java.util.Set;
@@ -163,9 +165,21 @@ public class BundleSynchronizer extends BundleSupport implements Synchronizer {
                                             LOGGER.debug("CELLAR BUNDLE: bundle located {} already started on node", state.getLocation());
                                         }
                                     } else if (state.getStatus() == Bundle.RESOLVED) {
-                                        if (isStarted(state.getLocation())) {
-                                            LOGGER.debug("CELLAR BUNDLE: stopping bundle {}/{} on node", symbolicName, version);
-                                            stopBundle(symbolicName, version);
+                                        if (!isInstalled(state.getLocation())) {
+                                            LOGGER.debug("CELLAR BUNDLE: installing bundle located {} on node", state.getLocation());
+                                            installBundleFromLocation(state.getLocation());
+                                        }
+                                        Bundle b = findBundle(state.getLocation());
+                                        if (b != null) {
+                                            if (b.getState() == Bundle.ACTIVE) {
+                                                LOGGER.debug("CELLAR BUNDLE: stopping bundle {}/{} on node", symbolicName, version);
+                                                stopBundle(symbolicName, version);
+                                            } else if (b.getState() == Bundle.INSTALLED) {
+                                                LOGGER.debug("CELLAR BUNDLE: resolving bundle {}/{} on node", symbolicName, version);
+                                                getBundleContext().getBundle(0).adapt(FrameworkWiring.class).resolveBundles(Collections.singleton(b));
+                                            }
+                                        } else {
+                                            LOGGER.warn("CELLAR BUNDLE: unable to find bundle located {} on node", state.getLocation());
                                         }
                                     }
                                 } catch (BundleException e) {

--- a/bundle/src/main/java/org/apache/karaf/cellar/bundle/BundleSynchronizer.java
+++ b/bundle/src/main/java/org/apache/karaf/cellar/bundle/BundleSynchronizer.java
@@ -162,6 +162,11 @@ public class BundleSynchronizer extends BundleSupport implements Synchronizer {
                                         } else {
                                             LOGGER.debug("CELLAR BUNDLE: bundle located {} already started on node", state.getLocation());
                                         }
+                                    } else if (state.getStatus() == Bundle.RESOLVED) {
+                                        if (isStarted(state.getLocation())) {
+                                            LOGGER.debug("CELLAR BUNDLE: stopping bundle {}/{} on node", symbolicName, version);
+                                            stopBundle(symbolicName, version);
+                                        }
                                     }
                                 } catch (BundleException e) {
                                     LOGGER.error("CELLAR BUNDLE: failed to pull bundle {}", id, e);


### PR DESCRIPTION
Ticket: https://issues.apache.org/jira/browse/KARAF-4708
Resolution: properly handle cluster bundles in Resolved state during pull, i.e. trigger stop for local one if it is currently Active