### PR TITLE
[KARAF-4722] cluster:bundle-list shell command ignores the supplied ids argument

### DIFF
--- a/bundle/src/main/java/org/apache/karaf/cellar/bundle/shell/ListBundleCommand.java
+++ b/bundle/src/main/java/org/apache/karaf/cellar/bundle/shell/ListBundleCommand.java
@@ -81,6 +81,15 @@ public class ListBundleCommand extends BundleCommandSupport {
                     table.column("Name");
                 }
 
+                if (ids != null && !ids.isEmpty()) {
+                    // do filtering by ids
+                    Set<String> matchingBundles = new HashSet<String>(selector(allBundles));
+                    for (Iterator<String> bundles = allBundles.keySet().iterator(); bundles.hasNext();) {
+                        if (!matchingBundles.contains(bundles.next())) {
+                            bundles.remove();
+                        }
+                    }
+                }
                 List<ExtendedBundleState> bundles = new ArrayList<ExtendedBundleState>(allBundles.values());
                 Collections.sort(bundles, new BundleStateComparator());
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KARAF-4722
Resolution: do filtering of displayed bundles by the supplied ids