### PR TITLE
[KARAF-6013] Make node alias a transient field

### DIFF
--- a/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/HazelcastNode.java
+++ b/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/HazelcastNode.java
@@ -27,7 +27,7 @@ public class HazelcastNode implements Node {
     private String id;
     private String host;
     private int port;
-    private String alias;
+    private transient String alias;
 
     public HazelcastNode(Member member) {
         InetSocketAddress address = member.getSocketAddress();


### PR DESCRIPTION
Hazelcast relies on serialization to store object, thus changing a node alias will make it unable to find by HazelcastGroupManager in map named "org.apache.karaf.cellar.groups" if the field is not transient.