### PR TITLE
Configuration factory synchronization

### DIFF
--- a/assembly/src/main/resources/node.cfg
+++ b/assembly/src/main/resources/node.cfg
@@ -44,4 +44,4 @@ handler.org.apache.karaf.cellar.http.balancer.BalancerEventHandler = true
 # Excluded config properties from the sync
 # Some config properties can be considered as local to a node, and should not be sync on the cluster.
 #
-config.excluded.properties = service.factoryPid, felix.fileinstall.filename, felix.fileinstall.dir, felix.fileinstall.tmpdir, org.ops4j.pax.url.mvn.defaultRepositories
+config.excluded.properties = felix.fileinstall.filename, felix.fileinstall.dir, felix.fileinstall.tmpdir, org.ops4j.pax.url.mvn.defaultRepositories

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
@@ -25,7 +25,6 @@ import org.osgi.service.cm.ConfigurationEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Dictionary;
 import java.util.Map;
 import java.util.Properties;
@@ -76,27 +75,31 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
         String pid = event.getId();
 
         if (isAllowed(event.getSourceGroup(), Constants.CATEGORY, pid, EventType.INBOUND)) {
-
-            Properties clusterDictionary = clusterConfigurations.get(pid);
+            Dictionary clusterDictionary = clusterConfigurations.get(pid);
             try {
                 // update the local configuration
-                Configuration[] localConfigurations = configurationAdmin.listConfigurations("(service.pid=" + pid + ")");
+                Configuration localConfiguration = findLocalConfiguration(pid, clusterDictionary);
+
                 if (event.getType() != null && event.getType() == ConfigurationEvent.CM_DELETED) {
                     // delete the configuration
-                    if (localConfigurations != null && localConfigurations.length > 0) {
-                        localConfigurations[0].delete();
+                    if (localConfiguration != null) {
+                        localConfiguration.delete();
                         deleteStorage(pid);
                     }
                 } else {
                     if (clusterDictionary != null) {
-                        Configuration localConfiguration = configurationAdmin.getConfiguration(pid, null);
+                        if (localConfiguration == null) {
+                            // Create new configuration
+                            localConfiguration = createLocalConfiguration(pid, clusterDictionary);
+                        }
                         Dictionary localDictionary = localConfiguration.getProperties();
                         if (localDictionary == null)
                             localDictionary = new Properties();
                         localDictionary = filter(localDictionary);
-                        if (!equals(clusterDictionary, localDictionary)) {
-                            localConfiguration.update((Dictionary) clusterDictionary);
-                            persistConfiguration(configurationAdmin, pid, clusterDictionary);
+                        if (!equals(clusterDictionary, localDictionary) && canDistributeConfig(localDictionary)) {
+                            Dictionary convertedDictionary = convertPropertiesFromCluster(clusterDictionary);
+                            localConfiguration.update(convertedDictionary);
+                            persistConfiguration(localConfiguration);
                         }
                     }
                 }

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
@@ -83,11 +83,10 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
                 if (event.getType() != null && event.getType() == ConfigurationEvent.CM_DELETED) {
                     // delete the configuration
                     if (localConfiguration != null) {
-                        localConfiguration.delete();
-                        deleteStorage(pid);
+                        deleteConfiguration(localConfiguration);
                     }
                 } else {
-                    if (clusterDictionary != null) {
+                    if (clusterDictionary != null && shouldReplicateConfig(clusterDictionary)) {
                         if (localConfiguration == null) {
                             // Create new configuration
                             localConfiguration = createLocalConfiguration(pid, clusterDictionary);

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
@@ -97,8 +97,9 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
                         localDictionary = filter(localDictionary);
                         if (!equals(clusterDictionary, localDictionary) && canDistributeConfig(localDictionary)) {
                             Dictionary convertedDictionary = convertPropertiesFromCluster(clusterDictionary);
+
                             localConfiguration.update(convertedDictionary);
-                            persistConfiguration(localConfiguration);
+                            persistConfiguration(localConfiguration, clusterDictionary);
                         }
                     }
                 }

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSupport.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSupport.java
@@ -29,10 +29,10 @@ import java.util.*;
  */
 public class ConfigurationSupport extends CellarSupport {
 
-    private static final String FELIX_FILEINSTALL_FILENAME = "felix.fileinstall.filename";
-    private static final String KARAF_CELLAR_FILENAME = "karaf.cellar.filename";
-    private static final String KARAF_CELLAR_CONTENT = "karaf.cellar.content";
-    private static final String KARAF_CELLAR_REMOVED = "karaf.cellar.removed";
+    public static final String FELIX_FILEINSTALL_FILENAME = "felix.fileinstall.filename";
+    public static final String KARAF_CELLAR_FILENAME = "karaf.cellar.filename";
+    public static final String KARAF_CELLAR_CONTENT = "karaf.cellar.content";
+    public static final String KARAF_CELLAR_REMOVED = "karaf.cellar.removed";
 
     protected File storage;
 
@@ -42,7 +42,7 @@ public class ConfigurationSupport extends CellarSupport {
      * @param dictionary the source dictionary.
      * @return the corresponding properties.
      */
-    public Properties dictionaryToProperties(Dictionary dictionary) {
+    public static Properties dictionaryToProperties(Dictionary dictionary) {
         Properties properties = new Properties();
         if (dictionary != null) {
             Enumeration keys = dictionary.keys();

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSupport.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSupport.java
@@ -15,6 +15,7 @@ package org.apache.karaf.cellar.config;
 
 import org.apache.karaf.cellar.core.CellarSupport;
 import org.apache.karaf.cellar.core.Configurations;
+import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 
@@ -30,6 +31,7 @@ import java.util.*;
 public class ConfigurationSupport extends CellarSupport {
 
     private static final String FELIX_FILEINSTALL_FILENAME = "felix.fileinstall.filename";
+    private static final String KARAF_CELLAR_FILENAME = "karaf.cellar.filename";
 
     protected File storage;
 
@@ -76,16 +78,25 @@ public class ConfigurationSupport extends CellarSupport {
         Enumeration sourceKeys = source.keys();
         while (sourceKeys.hasMoreElements()) {
             Object key = sourceKeys.nextElement();
-            Object sourceValue = source.get(key);
-            Object targetValue = target.get(key);
-            if (sourceValue != null && targetValue == null)
-                return false;
-            if (sourceValue == null && targetValue != null)
-                return false;
-            if (!sourceValue.equals(targetValue))
-                return false;
+            if (!key.equals(org.osgi.framework.Constants.SERVICE_PID)) {
+                Object sourceValue = source.get(key);
+                Object targetValue = target.get(key);
+                if (sourceValue != null && targetValue == null)
+                    return false;
+                if (sourceValue == null && targetValue != null)
+                    return false;
+                if (!sourceValue.equals(targetValue))
+                    return false;
+            }
         }
 
+        return true;
+    }
+
+    public boolean canDistributeConfig(Dictionary dictionary) {
+        if (dictionary.get(ConfigurationAdmin.SERVICE_FACTORYPID) != null) {
+            return dictionary.get(KARAF_CELLAR_FILENAME) != null;
+        }
         return true;
     }
 
@@ -101,7 +112,55 @@ public class ConfigurationSupport extends CellarSupport {
             Enumeration sourceKeys = dictionary.keys();
             while (sourceKeys.hasMoreElements()) {
                 String key = (String) sourceKeys.nextElement();
-                if (!isExcludedProperty(key)) {
+                if (key.equals(FELIX_FILEINSTALL_FILENAME)) {
+                    String value = dictionary.get(key).toString();
+                    value = value.substring(value.lastIndexOf(File.separatorChar) + 1);
+                    result.put(KARAF_CELLAR_FILENAME, value);
+                } else if (!isExcludedProperty(key)) {
+                    Object value = dictionary.get(key);
+                    result.put(key, value);
+                }
+            }
+        }
+        return result;
+    }
+
+    public Configuration findLocalConfiguration(String pid, Dictionary dictionary) throws IOException, InvalidSyntaxException {
+        String filter;
+        Object filename = dictionary != null ? dictionary.get(KARAF_CELLAR_FILENAME) : null;
+        if (filename != null) {
+            String uri = new File(storage, filename.toString()).toURI().toString();
+            filter = "(|(" + FELIX_FILEINSTALL_FILENAME + "=" + uri + ")(" + KARAF_CELLAR_FILENAME + "=" + dictionary.get(KARAF_CELLAR_FILENAME) + ")(" + org.osgi.framework.Constants.SERVICE_PID + "=" + pid + "))";
+        } else {
+            filter = "(" + org.osgi.framework.Constants.SERVICE_PID + "=" + pid + ")";
+        }
+
+        Configuration[] localConfigurations = configurationAdmin.listConfigurations(filter);
+
+        return (localConfigurations != null && localConfigurations.length > 0) ? localConfigurations[0] : null;
+    }
+
+    public Configuration createLocalConfiguration(String pid, Dictionary clusterDictionary) throws IOException {
+        Configuration localConfiguration;
+        Object factoryPid = clusterDictionary.get(ConfigurationAdmin.SERVICE_FACTORYPID);
+        if (factoryPid != null) {
+            localConfiguration = configurationAdmin.createFactoryConfiguration(factoryPid.toString(), null);
+        } else {
+            localConfiguration = configurationAdmin.getConfiguration(pid, null);
+        }
+        return localConfiguration;
+    }
+
+    public Dictionary convertPropertiesFromCluster(Dictionary dictionary) {
+        Dictionary result = new Properties();
+        if (dictionary != null) {
+            Enumeration sourceKeys = dictionary.keys();
+            while (sourceKeys.hasMoreElements()) {
+                String key = (String) sourceKeys.nextElement();
+                if (key.equals(KARAF_CELLAR_FILENAME)) {
+                    String value = dictionary.get(key).toString();
+                    result.put(FELIX_FILEINSTALL_FILENAME, new File(storage, value).toURI().toString());
+                } else {
                     Object value = dictionary.get(key);
                     result.put(key, value);
                 }
@@ -138,34 +197,18 @@ public class ConfigurationSupport extends CellarSupport {
 
     /**
      * Persist a configuration to a storage.
-     *
-     * @param admin the configuration admin service.
-     * @param pid the configuration PID to store.
-     * @param props the properties to store, linked to the configuration PID.
+     * @param cfg the configuration to store.
      */
-    protected void persistConfiguration(ConfigurationAdmin admin, String pid, Dictionary props) {
+    protected void persistConfiguration(Configuration cfg) {
         try {
-            if (pid.matches(".*-.*-.*-.*-.*")) {
-                // it's UUID
-                return;
+            File storageFile = getStorageFile(cfg.getProperties());
+
+            if (storageFile == null && cfg.getProperties().get(ConfigurationAdmin.SERVICE_FACTORYPID) != null) {
+                storageFile = new File(storage, cfg.getPid() + ".cfg");
             }
-            File storageFile = new File(storage, pid + ".cfg");
-            Configuration cfg = admin.getConfiguration(pid, null);
-            if (cfg != null && cfg.getProperties() != null) {
-                Object val = cfg.getProperties().get(FELIX_FILEINSTALL_FILENAME);
-                try {
-                    if (val instanceof URL) {
-                        storageFile = new File(((URL) val).toURI());
-                    }
-                    if (val instanceof URI) {
-                        storageFile = new File((URI) val);
-                    }
-                    if (val instanceof String) {
-                        storageFile = new File(new URL((String) val).toURI());
-                    }
-                } catch (Exception e) {
-                    throw new IOException(e.getMessage(), e);
-                }
+            if (storageFile == null) {
+                // it's a factory configuration without filename specified, cannot save
+                return;
             }
 
             org.apache.felix.utils.properties.Properties p = new org.apache.felix.utils.properties.Properties(storageFile);
@@ -175,6 +218,7 @@ public class ConfigurationSupport extends CellarSupport {
             for (String key : set) {
                 if (!org.osgi.framework.Constants.SERVICE_PID.equals(key)
                         && !ConfigurationAdmin.SERVICE_FACTORYPID.equals(key)
+                        && !KARAF_CELLAR_FILENAME.equals(key)
                         && !FELIX_FILEINSTALL_FILENAME.equals(key)) {
                     propertiesToRemove.add(key);
                 }
@@ -183,11 +227,12 @@ public class ConfigurationSupport extends CellarSupport {
             for (String key : propertiesToRemove) {
                 p.remove(key);
             }
-
+            Dictionary props = cfg.getProperties();
             for (Enumeration<String> keys = props.keys(); keys.hasMoreElements(); ) {
                 String key = keys.nextElement();
                 if (!org.osgi.framework.Constants.SERVICE_PID.equals(key)
                         && !ConfigurationAdmin.SERVICE_FACTORYPID.equals(key)
+                        && !KARAF_CELLAR_FILENAME.equals(key)
                         && !FELIX_FILEINSTALL_FILENAME.equals(key)) {
                     p.put(key, (String) props.get(key));
                 }
@@ -199,6 +244,29 @@ public class ConfigurationSupport extends CellarSupport {
         } catch (Exception e) {
             // nothing to do
         }
+    }
+
+    private File getStorageFile(Dictionary properties) throws IOException {
+        File storageFile = null;
+        Object val = properties.get(FELIX_FILEINSTALL_FILENAME);
+        try {
+            if (val instanceof URL) {
+                storageFile = new File(((URL) val).toURI());
+            }
+            if (val instanceof URI) {
+                storageFile = new File((URI) val);
+            }
+            if (val instanceof String) {
+                storageFile = new File(new URL((String) val).toURI());
+            }
+        } catch (Exception e) {
+            throw new IOException(e.getMessage(), e);
+        }
+        return storageFile;
+    }
+
+    public String getKarafFilename(Dictionary dictionary) {
+        return (String) filter(dictionary).get(KARAF_CELLAR_FILENAME);
     }
 
     /**

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSupport.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSupport.java
@@ -18,7 +18,6 @@ import org.apache.karaf.cellar.core.Configurations;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
-import shaded.org.apache.commons.io.FileUtils;
 
 import java.io.*;
 import java.net.URI;
@@ -120,7 +119,7 @@ public class ConfigurationSupport extends CellarSupport {
                 String key = (String) sourceKeys.nextElement();
                 if (key.equals(FELIX_FILEINSTALL_FILENAME)) {
                     String value = dictionary.get(key).toString();
-                    value = value.substring(value.lastIndexOf(File.separatorChar) + 1);
+                    value = value.substring(value.lastIndexOf("/") + 1);
                     result.put(KARAF_CELLAR_FILENAME, value);
                     try {
                         result.put(KARAF_CELLAR_CONTENT, readFile(new File(storage, value)));
@@ -269,7 +268,7 @@ public class ConfigurationSupport extends CellarSupport {
                 writeFile(storageFile, content);
             }
         } catch (Exception e) {
-            // nothing to do
+            LOGGER.error("CELLAR CONFIG: Issue when trying to persist configuration file", e);
         }
     }
 

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
@@ -160,7 +160,7 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                         filenames.remove(null);
                         for (Configuration configuration : configurationAdmin.listConfigurations(null)) {
                             String pid = configuration.getPid();
-                            if (!clusterConfigurations.containsKey(pid) && !filenames.contains(getKarafFilename(configuration.getProperties())) && isAllowed(group, Constants.CATEGORY, pid, EventType.INBOUND)) {
+                            if ((!clusterConfigurations.containsKey(pid) || !shouldReplicateConfig(clusterConfigurations.get(pid))) && !filenames.contains(getKarafFilename(configuration.getProperties())) && isAllowed(group, Constants.CATEGORY, pid, EventType.INBOUND)) {
                                 LOGGER.debug("CELLAR CONFIG: deleting local configuration {} which is not present in cluster", pid);
                                 deleteConfiguration(configuration);
                             }

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
@@ -137,7 +137,7 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                                 localDictionary = new Properties();
 
                             localDictionary = filter(localDictionary);
-                            if (!equals(clusterDictionary, localDictionary) && canDistributeConfig(localDictionary)) {
+                            if (!equals(clusterDictionary, localDictionary) && canDistributeConfig(localDictionary) && shouldReplicateConfig(clusterDictionary)) {
                                 LOGGER.debug("CELLAR CONFIG: updating configration {} on node", pid);
                                 clusterDictionary = convertPropertiesFromCluster(clusterDictionary);
                                 localConfiguration.update((Dictionary) clusterDictionary);
@@ -160,7 +160,7 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                             String pid = configuration.getPid();
                             if (!clusterConfigurations.containsKey(pid) && !filenames.contains(getKarafFilename(configuration.getProperties())) && isAllowed(group, Constants.CATEGORY, pid, EventType.INBOUND)) {
                                 LOGGER.debug("CELLAR CONFIG: deleting local configuration {} which is not present in cluster", pid);
-                                configuration.delete();
+                                deleteConfiguration(configuration);
                             }
                         }
                     } catch (Exception e) {

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
@@ -123,7 +123,7 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
 
                 // get configurations on the cluster to update local configurations
                 for (String pid : clusterConfigurations.keySet()) {
-                    if (isAllowed(group, Constants.CATEGORY, pid, EventType.INBOUND)) {
+                    if (isAllowed(group, Constants.CATEGORY, pid, EventType.INBOUND) && shouldReplicateConfig(clusterConfigurations.get(pid))) {
                         Dictionary clusterDictionary = clusterConfigurations.get(pid);
                         try {
                             // update the local configuration if needed
@@ -153,7 +153,9 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                     try {
                         Set<String> filenames = new HashSet();
                         for (Properties configuration : clusterConfigurations.values()) {
-                            filenames.add(getKarafFilename(configuration));
+                            if (shouldReplicateConfig(configuration)) {
+                                filenames.add(getKarafFilename(configuration));
+                            }
                         }
                         filenames.remove(null);
                         for (Configuration configuration : configurationAdmin.listConfigurations(null)) {

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
@@ -237,14 +237,7 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                     // clean configurations on the cluster not present locally
                     for (String pid : clusterConfigurations.keySet()) {
                         if (isAllowed(group, Constants.CATEGORY, pid, EventType.OUTBOUND)) {
-                            boolean found = false;
-                            for (Configuration configuration : configurationAdmin.listConfigurations(null)) {
-                                if (configuration.getPid().equals(pid)) {
-                                    found = true;
-                                    break;
-                                }
-                            }
-                            if (!found) {
+                            if (findLocalConfiguration(pid,clusterConfigurations.get(pid)) == null) {
                                 clusterConfigurations.remove(pid);
                             }
                         }

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
@@ -141,7 +141,7 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                                 LOGGER.debug("CELLAR CONFIG: updating configration {} on node", pid);
                                 clusterDictionary = convertPropertiesFromCluster(clusterDictionary);
                                 localConfiguration.update((Dictionary) clusterDictionary);
-                                persistConfiguration(localConfiguration);
+                                persistConfiguration(localConfiguration, clusterDictionary);
                             }
                         } catch (IOException ex) {
                             LOGGER.error("CELLAR CONFIG: failed to read local configuration", ex);

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
@@ -28,10 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Dictionary;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 
 /**
  * The ConfigurationSynchronizer is called when Cellar starts or when a node joins a cluster group.
@@ -130,16 +127,21 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                         Dictionary clusterDictionary = clusterConfigurations.get(pid);
                         try {
                             // update the local configuration if needed
-                            Configuration localConfiguration = configurationAdmin.getConfiguration(pid, null);
+                            Configuration localConfiguration = findLocalConfiguration(pid, clusterDictionary);
+                            if (localConfiguration == null) {
+                                // Create new configuration
+                                localConfiguration = createLocalConfiguration(pid, clusterDictionary);
+                            }
                             Dictionary localDictionary = localConfiguration.getProperties();
                             if (localDictionary == null)
                                 localDictionary = new Properties();
 
                             localDictionary = filter(localDictionary);
-                            if (!equals(clusterDictionary, localDictionary)) {
+                            if (!equals(clusterDictionary, localDictionary) && canDistributeConfig(localDictionary)) {
                                 LOGGER.debug("CELLAR CONFIG: updating configration {} on node", pid);
+                                clusterDictionary = convertPropertiesFromCluster(clusterDictionary);
                                 localConfiguration.update((Dictionary) clusterDictionary);
-                                persistConfiguration(configurationAdmin, pid, clusterDictionary);
+                                persistConfiguration(localConfiguration);
                             }
                         } catch (IOException ex) {
                             LOGGER.error("CELLAR CONFIG: failed to read local configuration", ex);
@@ -149,9 +151,15 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                 // cleanup the local configurations not present on the cluster if the node is not the first one in the cluster
                 if (clusterManager.listNodesByGroup(group).size() > 1) {
                     try {
+                        Set<String> filenames = new HashSet();
+                        for (Properties configuration : clusterConfigurations.values()) {
+                            filenames.add(getKarafFilename(configuration));
+                        }
+                        filenames.remove(null);
                         for (Configuration configuration : configurationAdmin.listConfigurations(null)) {
                             String pid = configuration.getPid();
-                            if (!clusterConfigurations.containsKey(pid) && isAllowed(group, Constants.CATEGORY, pid, EventType.INBOUND)) {
+                            if (!clusterConfigurations.containsKey(pid) && !filenames.contains(getKarafFilename(configuration.getProperties())) && isAllowed(group, Constants.CATEGORY, pid, EventType.INBOUND)) {
+                                LOGGER.debug("CELLAR CONFIG: deleting local configuration {} which is not present in cluster", pid);
                                 configuration.delete();
                             }
                         }
@@ -159,6 +167,8 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                         LOGGER.warn("Can't get local configurations", e);
                     }
                 }
+            } catch (Exception ex) {
+                LOGGER.error("CELLAR CONFIG: failed to read cluster configuration", ex);
             } finally {
                 Thread.currentThread().setContextClassLoader(originalClassLoader);
             }
@@ -207,7 +217,7 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                                 eventProducer.produce(event);
                             } else {
                                 Dictionary clusterDictionary = clusterConfigurations.get(pid);
-                                if (!equals(clusterDictionary, localDictionary)) {
+                                if (!equals(clusterDictionary, localDictionary) && canDistributeConfig(localDictionary)) {
                                     LOGGER.debug("CELLAR CONFIG: updating configuration pid {} on the cluster", pid);
                                     // update cluster configurations
                                     clusterConfigurations.put(pid, dictionaryToProperties(localDictionary));

--- a/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
@@ -24,7 +24,10 @@ import org.osgi.service.cm.ConfigurationListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.Dictionary;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 
 /**
  * LocalConfigurationListener is listening for local configuration changes.
@@ -89,7 +92,7 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
 
                             Properties distributedDictionary = clusterConfigurations.get(pid);
 
-                            if (!equals(localDictionary, distributedDictionary)) {
+                            if (!equals(localDictionary, distributedDictionary) && canDistributeConfig(localDictionary)) {
                                 // update the configurations in the cluster group
                                 clusterConfigurations.put(pid, dictionaryToProperties(localDictionary));
                                 // send the cluster event

--- a/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
@@ -24,10 +24,7 @@ import org.osgi.service.cm.ConfigurationListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Dictionary;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 
 /**
  * LocalConfigurationListener is listening for local configuration changes.
@@ -74,7 +71,7 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
 
                             if (clusterConfigurations.containsKey(pid)) {
                                 // update the configurations in the cluster group
-                                clusterConfigurations.remove(pid);
+                                clusterConfigurations.put(pid, getDeletedConfigurationMarker(clusterConfigurations.get(pid)));
                                 // send the cluster event
                                 ClusterConfigurationEvent clusterConfigurationEvent = new ClusterConfigurationEvent(pid);
                                 clusterConfigurationEvent.setType(event.getType());

--- a/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
@@ -70,8 +70,17 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
                         if (event.getType() == ConfigurationEvent.CM_DELETED) {
 
                             if (clusterConfigurations.containsKey(pid)) {
-                                // update the configurations in the cluster group
-                                clusterConfigurations.put(pid, getDeletedConfigurationMarker(clusterConfigurations.get(pid)));
+                                String filename = (String) clusterConfigurations.get(pid).get(KARAF_CELLAR_FILENAME);
+                                List<String> matchingPids = new ArrayList<String>();
+                                for (Map.Entry<String, Properties> entry : clusterConfigurations.entrySet()) {
+                                    if (filename.equals(entry.getValue().get(KARAF_CELLAR_FILENAME))) {
+                                        matchingPids.add(entry.getKey());
+                                    }
+                                }
+                                for (String matchingPid : matchingPids) {
+                                    // update the configurations in the cluster group
+                                    clusterConfigurations.put(matchingPid, getDeletedConfigurationMarker(clusterConfigurations.get(matchingPid)));
+                                }
                                 // send the cluster event
                                 ClusterConfigurationEvent clusterConfigurationEvent = new ClusterConfigurationEvent(pid);
                                 clusterConfigurationEvent.setType(event.getType());
@@ -80,7 +89,6 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
                                 clusterConfigurationEvent.setLocal(clusterManager.getNode());
                                 eventProducer.produce(clusterConfigurationEvent);
                             }
-
                         } else {
 
                             Configuration conf = configurationAdmin.getConfiguration(pid, null);

--- a/config/src/main/java/org/apache/karaf/cellar/config/internal/osgi/Activator.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/internal/osgi/Activator.java
@@ -97,6 +97,7 @@ public class Activator extends BaseActivator implements ManagedService {
         localConfigurationListener.setGroupManager(groupManager);
         localConfigurationListener.setConfigurationAdmin(configurationAdmin);
         localConfigurationListener.setEventProducer(eventProducer);
+        localConfigurationListener.setStorage(storage);
         localConfigurationListener.init();
         register(ConfigurationListener.class, localConfigurationListener);
 

--- a/config/src/main/java/org/apache/karaf/cellar/config/shell/ListCommand.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/shell/ListCommand.java
@@ -127,7 +127,6 @@ public class ListCommand extends ConfigCommandSupport {
     private Map<String, ConfigurationState> gatherConfigurations() throws Exception {
         Map<String, ConfigurationState> configurations = new HashMap<String, ConfigurationState>();
         Map<String, List<ConfigurationState>> configurationsByFileName = new HashMap<String, List<ConfigurationState>>();
-        ConfigurationSupport support = new ConfigurationSupport();
 
         // retrieve cluster configurations
         Map<String, Properties> clusterConfigurations = clusterManager.getMap(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName);
@@ -139,7 +138,7 @@ public class ListCommand extends ConfigCommandSupport {
             state.setCluster(true);
             state.setLocal(false);
             configurations.put(key, state);
-            String filename = support.getKarafFilename(properties);
+            String filename = properties.getProperty(ConfigurationSupport.KARAF_CELLAR_FILENAME);
             if (filename != null) {
                 configurationsByFileName.putIfAbsent(filename, new ArrayList<ConfigurationState>());
                 configurationsByFileName.get(filename).add(state);
@@ -150,13 +149,13 @@ public class ListCommand extends ConfigCommandSupport {
         for (Configuration configuration : configurationAdmin.listConfigurations(null)) {
             String key = configuration.getPid();
 
-            String filename = support.getKarafFilename(configuration.getProperties());
+            String filename = (String) configuration.getProperties().get(ConfigurationSupport.KARAF_CELLAR_FILENAME);
 
             ConfigurationState state = configurations.get(key);
             if (state == null) {
                 state = new ConfigurationState();
                 state.setCluster(false);
-                state.setProperties(support.dictionaryToProperties(configuration.getProperties()));
+                state.setProperties(ConfigurationSupport.dictionaryToProperties(configuration.getProperties()));
                 configurations.put(key, state);
             }
             state.setLocal(true);

--- a/config/src/main/java/org/apache/karaf/cellar/config/shell/ListCommand.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/shell/ListCommand.java
@@ -26,10 +26,7 @@ import org.apache.karaf.shell.api.action.Option;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 import org.osgi.service.cm.Configuration;
 
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 
 @Command(scope = "cluster", name = "config-list", description = "List the configurations in a cluster group")
 @Service
@@ -90,6 +87,9 @@ public class ListCommand extends ConfigCommandSupport {
                         if (onlyCluster)
                             continue;
                     }
+                    if (state.getClusterPids() != null && !state.getClusterPids().isEmpty()) {
+                        located += " (cluster = " + state.getClusterPids() + ")";
+                    }
 
                     String blocked = "";
                     boolean inbound = support.isAllowed(group, Constants.CATEGORY, pid, EventType.INBOUND);
@@ -126,31 +126,51 @@ public class ListCommand extends ConfigCommandSupport {
 
     private Map<String, ConfigurationState> gatherConfigurations() throws Exception {
         Map<String, ConfigurationState> configurations = new HashMap<String, ConfigurationState>();
+        Map<String, List<ConfigurationState>> configurationsByFileName = new HashMap<String, List<ConfigurationState>>();
+        ConfigurationSupport support = new ConfigurationSupport();
 
         // retrieve cluster configurations
         Map<String, Properties> clusterConfigurations = clusterManager.getMap(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName);
         for (String key : clusterConfigurations.keySet()) {
             Properties properties = clusterConfigurations.get(key);
             ConfigurationState state = new ConfigurationState();
+            state.setPid(key);
             state.setProperties(properties);
             state.setCluster(true);
             state.setLocal(false);
             configurations.put(key, state);
+            String filename = support.getKarafFilename(properties);
+            if (filename != null) {
+                configurationsByFileName.putIfAbsent(filename, new ArrayList<ConfigurationState>());
+                configurationsByFileName.get(filename).add(state);
+            }
         }
 
         // retrieve local configurations
         for (Configuration configuration : configurationAdmin.listConfigurations(null)) {
             String key = configuration.getPid();
-            if (configurations.containsKey(key)) {
-                ConfigurationState state = configurations.get(key);
-                state.setLocal(true);
-            } else {
-                ConfigurationState state = new ConfigurationState();
-                state.setLocal(true);
+
+            String filename = support.getKarafFilename(configuration.getProperties());
+
+            ConfigurationState state = configurations.get(key);
+            if (state == null) {
+                state = new ConfigurationState();
                 state.setCluster(false);
-                ConfigurationSupport support = new ConfigurationSupport();
                 state.setProperties(support.dictionaryToProperties(configuration.getProperties()));
                 configurations.put(key, state);
+            }
+            state.setLocal(true);
+
+            if (filename != null && configurationsByFileName.containsKey(filename)) {
+                state.setCluster(true);
+                state.setClusterPids(new ArrayList<String>());
+                List<ConfigurationState> states = configurationsByFileName.get(filename);
+                for (ConfigurationState otherState : states) {
+                    if (!otherState.getPid().equals(key)) {
+                        configurations.remove(otherState.getPid());
+                        state.getClusterPids().add(otherState.getPid());
+                    }
+                }
             }
         }
 
@@ -162,6 +182,8 @@ public class ListCommand extends ConfigCommandSupport {
         private Properties properties;
         private boolean cluster;
         private boolean local;
+        private String pid;
+        private List<String> clusterPids;
 
         public Properties getProperties() {
             return properties;
@@ -185,6 +207,22 @@ public class ListCommand extends ConfigCommandSupport {
 
         public void setLocal(boolean local) {
             this.local = local;
+        }
+
+        public String getPid() {
+            return pid;
+        }
+
+        public void setPid(String pid) {
+            this.pid = pid;
+        }
+
+        public List<String> getClusterPids() {
+            return clusterPids;
+        }
+
+        public void setClusterPids(List<String> clusterPids) {
+            this.clusterPids = clusterPids;
         }
     }
 


### PR DESCRIPTION
Hi,

This PR allows to correctly synchronize factory configurations across the cluster. 
The main issue with factory configuration is that pid cannot be the same across nodes - the idea here is to take the fileinstall filename, if it is available, to find the local matching configuration. If no filename is available replication is skipped to avoid endless loop. Different changes were required to correctly handle the fact that pid cannot be used to identify these configurations.

Also added an improvement if configuration is coming from a cfg file installed via fileinstall, send the file content in cluster map instead of serializing properties.
