### PR TITLE
Synchronizer map

### DIFF
--- a/bundle/src/main/java/org/apache/karaf/cellar/bundle/BundleSynchronizer.java
+++ b/bundle/src/main/java/org/apache/karaf/cellar/bundle/BundleSynchronizer.java
@@ -122,7 +122,6 @@ public class BundleSynchronizer extends BundleSupport implements Synchronizer {
             String groupName = group.getName();
             LOGGER.debug("CELLAR BUNDLE: pulling bundles from cluster group {}", groupName);
             Map<String, BundleState> clusterBundles = clusterManager.getMap(Constants.BUNDLE_MAP + Configurations.SEPARATOR + groupName);
-            Map<String, Boolean> synchronizers = clusterManager.getMap("org.apache.karaf.cellar.bundle.synchronizers");
 
             ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
 
@@ -185,12 +184,13 @@ public class BundleSynchronizer extends BundleSupport implements Synchronizer {
                     }
                 }
                 // cleanup the local bundles not present on the cluster if the node is not the first one in the cluster group
-                if (synchronizers.containsKey(Constants.BUNDLE_MAP + Configurations.SEPARATOR + groupName)) {
+                if (getSynchronizerMap().containsKey(Constants.BUNDLE_MAP + Configurations.SEPARATOR + groupName)) {
                     for (Bundle bundle : bundleContext.getBundles()) {
                         String id = getId(bundle);
                         if (!clusterBundles.containsKey(id) && isAllowed(group, Constants.CATEGORY, bundle.getLocation(), EventType.INBOUND)) {
                             // the bundle is not present on the cluster, so it has to be uninstalled locally
                             try {
+                                LOGGER.debug("CELLAR BUNDLE: uninstalling local bundle {} which is not present in cluster", id);
                                 bundle.uninstall();
                             } catch (Exception e) {
                                 LOGGER.warn("Can't uninstall {}", id, e);
@@ -221,7 +221,6 @@ public class BundleSynchronizer extends BundleSupport implements Synchronizer {
             String groupName = group.getName();
             LOGGER.debug("CELLAR BUNDLE: pushing bundles to cluster group {}", groupName);
             Map<String, BundleState> clusterBundles = clusterManager.getMap(Constants.BUNDLE_MAP + Configurations.SEPARATOR + groupName);
-            Map<String, Boolean> synchronizers = clusterManager.getMap("org.apache.karaf.cellar.bundle.synchronizers");
 
             ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
             try {
@@ -303,7 +302,7 @@ public class BundleSynchronizer extends BundleSupport implements Synchronizer {
                         }
                     }
                 }
-                synchronizers.put(Constants.BUNDLE_MAP + Configurations.SEPARATOR + groupName, true);
+                getSynchronizerMap().putIfAbsent(Constants.BUNDLE_MAP + Configurations.SEPARATOR + groupName, true);
             } finally {
                 Thread.currentThread().setContextClassLoader(originalClassLoader);
             }

--- a/bundle/src/main/java/org/apache/karaf/cellar/bundle/BundleSynchronizer.java
+++ b/bundle/src/main/java/org/apache/karaf/cellar/bundle/BundleSynchronizer.java
@@ -19,6 +19,7 @@ import org.apache.karaf.cellar.core.Synchronizer;
 import org.apache.karaf.cellar.core.control.SwitchStatus;
 import org.apache.karaf.cellar.core.event.EventProducer;
 import org.apache.karaf.cellar.core.event.EventType;
+import org.apache.karaf.cellar.core.utils.CellarUtils;
 import org.apache.karaf.features.BootFinished;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -184,7 +185,7 @@ public class BundleSynchronizer extends BundleSupport implements Synchronizer {
                     }
                 }
                 // cleanup the local bundles not present on the cluster if the node is not the first one in the cluster group
-                if (getSynchronizerMap().containsKey(Constants.BUNDLE_MAP + Configurations.SEPARATOR + groupName)) {
+                if (CellarUtils.doCleanupResourcesNotPresentInCluster(configurationAdmin) && getSynchronizerMap().containsKey(Constants.BUNDLE_MAP + Configurations.SEPARATOR + groupName)) {
                     for (Bundle bundle : bundleContext.getBundles()) {
                         String id = getId(bundle);
                         if (!clusterBundles.containsKey(id) && isAllowed(group, Constants.CATEGORY, bundle.getLocation(), EventType.INBOUND)) {

--- a/bundle/src/main/java/org/apache/karaf/cellar/bundle/BundleSynchronizer.java
+++ b/bundle/src/main/java/org/apache/karaf/cellar/bundle/BundleSynchronizer.java
@@ -122,6 +122,7 @@ public class BundleSynchronizer extends BundleSupport implements Synchronizer {
             String groupName = group.getName();
             LOGGER.debug("CELLAR BUNDLE: pulling bundles from cluster group {}", groupName);
             Map<String, BundleState> clusterBundles = clusterManager.getMap(Constants.BUNDLE_MAP + Configurations.SEPARATOR + groupName);
+            Map<String, Boolean> synchronizers = clusterManager.getMap("org.apache.karaf.cellar.bundle.synchronizers");
 
             ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
 
@@ -184,7 +185,7 @@ public class BundleSynchronizer extends BundleSupport implements Synchronizer {
                     }
                 }
                 // cleanup the local bundles not present on the cluster if the node is not the first one in the cluster group
-                if (clusterManager.listNodesByGroup(group).size() > 1) {
+                if (synchronizers.containsKey(Constants.BUNDLE_MAP + Configurations.SEPARATOR + groupName)) {
                     for (Bundle bundle : bundleContext.getBundles()) {
                         String id = getId(bundle);
                         if (!clusterBundles.containsKey(id) && isAllowed(group, Constants.CATEGORY, bundle.getLocation(), EventType.INBOUND)) {
@@ -220,6 +221,7 @@ public class BundleSynchronizer extends BundleSupport implements Synchronizer {
             String groupName = group.getName();
             LOGGER.debug("CELLAR BUNDLE: pushing bundles to cluster group {}", groupName);
             Map<String, BundleState> clusterBundles = clusterManager.getMap(Constants.BUNDLE_MAP + Configurations.SEPARATOR + groupName);
+            Map<String, Boolean> synchronizers = clusterManager.getMap("org.apache.karaf.cellar.bundle.synchronizers");
 
             ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
             try {
@@ -301,6 +303,7 @@ public class BundleSynchronizer extends BundleSupport implements Synchronizer {
                         }
                     }
                 }
+                synchronizers.put(Constants.BUNDLE_MAP + Configurations.SEPARATOR + groupName, true);
             } finally {
                 Thread.currentThread().setContextClassLoader(originalClassLoader);
             }

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
@@ -19,6 +19,7 @@ import org.apache.karaf.cellar.core.Synchronizer;
 import org.apache.karaf.cellar.core.control.SwitchStatus;
 import org.apache.karaf.cellar.core.event.EventProducer;
 import org.apache.karaf.cellar.core.event.EventType;
+import org.apache.karaf.cellar.core.utils.CellarUtils;
 import org.apache.karaf.features.BootFinished;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
@@ -148,7 +149,7 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                     } else  LOGGER.trace("CELLAR CONFIG: configuration with PID {} is marked BLOCKED INBOUND for cluster group {}", pid, groupName);
                 }
                 // cleanup the local configurations not present on the cluster if the node is not the first one in the cluster
-                if (getSynchronizerMap().containsKey(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName)) {
+                if (CellarUtils.doCleanupResourcesNotPresentInCluster(configurationAdmin) && getSynchronizerMap().containsKey(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName)) {
                     try {
                         Set<String> filenames = new HashSet();
                         for (Properties configuration : clusterConfigurations.values()) {

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
@@ -115,6 +115,7 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
             LOGGER.debug("CELLAR CONFIG: pulling configurations from cluster group {}", groupName);
 
             Map<String, Properties> clusterConfigurations = clusterManager.getMap(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName);
+            Map<String, Boolean> synchronizers = clusterManager.getMap("org.apache.karaf.cellar.bundle.synchronizers");
 
             ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
             try {
@@ -148,7 +149,7 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                     } else  LOGGER.trace("CELLAR CONFIG: configuration with PID {} is marked BLOCKED INBOUND for cluster group {}", pid, groupName);
                 }
                 // cleanup the local configurations not present on the cluster if the node is not the first one in the cluster
-                if (clusterManager.listNodesByGroup(group).size() > 1) {
+                if (synchronizers.containsKey(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName)) {
                     try {
                         Set<String> filenames = new HashSet();
                         for (Properties configuration : clusterConfigurations.values()) {
@@ -192,6 +193,7 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
             String groupName = group.getName();
             LOGGER.debug("CELLAR CONFIG: pushing configurations to cluster group {}", groupName);
             Map<String, Properties> clusterConfigurations = clusterManager.getMap(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName);
+            Map<String, Boolean> synchronizers = clusterManager.getMap("org.apache.karaf.cellar.bundle.synchronizers");
 
             ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
             try {
@@ -241,6 +243,7 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                             }
                         }
                     }
+                    synchronizers.put(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName, true);
                 } catch (IOException ex) {
                     LOGGER.error("CELLAR CONFIG: failed to read configuration (IO error)", ex);
                 } catch (InvalidSyntaxException ex) {

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
@@ -115,7 +115,6 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
             LOGGER.debug("CELLAR CONFIG: pulling configurations from cluster group {}", groupName);
 
             Map<String, Properties> clusterConfigurations = clusterManager.getMap(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName);
-            Map<String, Boolean> synchronizers = clusterManager.getMap("org.apache.karaf.cellar.bundle.synchronizers");
 
             ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
             try {
@@ -149,7 +148,7 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                     } else  LOGGER.trace("CELLAR CONFIG: configuration with PID {} is marked BLOCKED INBOUND for cluster group {}", pid, groupName);
                 }
                 // cleanup the local configurations not present on the cluster if the node is not the first one in the cluster
-                if (synchronizers.containsKey(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName)) {
+                if (getSynchronizerMap().containsKey(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName)) {
                     try {
                         Set<String> filenames = new HashSet();
                         for (Properties configuration : clusterConfigurations.values()) {
@@ -193,7 +192,6 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
             String groupName = group.getName();
             LOGGER.debug("CELLAR CONFIG: pushing configurations to cluster group {}", groupName);
             Map<String, Properties> clusterConfigurations = clusterManager.getMap(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName);
-            Map<String, Boolean> synchronizers = clusterManager.getMap("org.apache.karaf.cellar.bundle.synchronizers");
 
             ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
             try {
@@ -243,7 +241,7 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                             }
                         }
                     }
-                    synchronizers.put(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName, true);
+                    getSynchronizerMap().putIfAbsent(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName, true);
                 } catch (IOException ex) {
                     LOGGER.error("CELLAR CONFIG: failed to read configuration (IO error)", ex);
                 } catch (InvalidSyntaxException ex) {

--- a/core/src/main/java/org/apache/karaf/cellar/core/CellarSupport.java
+++ b/core/src/main/java/org/apache/karaf/cellar/core/CellarSupport.java
@@ -248,4 +248,8 @@ public class CellarSupport {
         this.groupManager = groupManager;
     }
 
+    @SuppressWarnings("unchecked")
+    protected Map<String, Boolean> getSynchronizerMap() {
+        return clusterManager.getMap("org.apache.karaf.cellar.synchronizers");
+    }
 }

--- a/features/src/main/java/org/apache/karaf/cellar/features/FeaturesSynchronizer.java
+++ b/features/src/main/java/org/apache/karaf/cellar/features/FeaturesSynchronizer.java
@@ -122,6 +122,7 @@ public class FeaturesSynchronizer extends FeaturesSupport implements Synchronize
 
                 Map<String, String> clusterRepositories = clusterManager.getMap(Constants.REPOSITORIES_MAP + Configurations.SEPARATOR + groupName);
                 Map<String, FeatureState> clusterFeatures = clusterManager.getMap(Constants.FEATURES_MAP + Configurations.SEPARATOR + groupName);
+                Map<String, Boolean> synchronizers = clusterManager.getMap("org.apache.karaf.cellar.bundle.synchronizers");
 
                 if (clusterRepositories != null && !clusterRepositories.isEmpty()) {
                     // get the features repositories from the cluster to update locally
@@ -138,7 +139,8 @@ public class FeaturesSynchronizer extends FeaturesSupport implements Synchronize
                         }
                     }
                     // cleanup the local features repositories not present on the cluster if the node is not the first one in the cluster group
-                    if (clusterManager.listNodesByGroup(group).size() > 1) {
+
+                    if (synchronizers.containsKey(Constants.REPOSITORIES_MAP + Configurations.SEPARATOR + groupName)) {
                         try {
                             for (Repository repository : featuresService.listRepositories()) {
                                 URI uri = repository.getURI();
@@ -227,6 +229,7 @@ public class FeaturesSynchronizer extends FeaturesSupport implements Synchronize
 
                 Map<String, String> clusterRepositories = clusterManager.getMap(Constants.REPOSITORIES_MAP + Configurations.SEPARATOR + groupName);
                 Map<String, FeatureState> clusterFeatures = clusterManager.getMap(Constants.FEATURES_MAP + Configurations.SEPARATOR + groupName);
+                Map<String, Boolean> synchronizers = clusterManager.getMap("org.apache.karaf.cellar.bundle.synchronizers");
 
                 Repository[] repositoryList = new Repository[0];
                 Feature[] featuresList = new Feature[0];
@@ -260,6 +263,7 @@ public class FeaturesSynchronizer extends FeaturesSupport implements Synchronize
                         }
                     }
                 }
+                synchronizers.put(Constants.REPOSITORIES_MAP + Configurations.SEPARATOR + groupName, true);
 
                 // push features to the cluster group
                 if (featuresList != null && featuresList.length > 0) {

--- a/features/src/main/java/org/apache/karaf/cellar/features/FeaturesSynchronizer.java
+++ b/features/src/main/java/org/apache/karaf/cellar/features/FeaturesSynchronizer.java
@@ -122,7 +122,7 @@ public class FeaturesSynchronizer extends FeaturesSupport implements Synchronize
 
                 Map<String, String> clusterRepositories = clusterManager.getMap(Constants.REPOSITORIES_MAP + Configurations.SEPARATOR + groupName);
                 Map<String, FeatureState> clusterFeatures = clusterManager.getMap(Constants.FEATURES_MAP + Configurations.SEPARATOR + groupName);
-                Map<String, Boolean> synchronizers = clusterManager.getMap("org.apache.karaf.cellar.bundle.synchronizers");
+                Map<String, Boolean> synchronizers = getSynchronizerMap();
 
                 if (clusterRepositories != null && !clusterRepositories.isEmpty()) {
                     // get the features repositories from the cluster to update locally
@@ -163,6 +163,7 @@ public class FeaturesSynchronizer extends FeaturesSupport implements Synchronize
                 }
 
                 if (clusterFeatures != null && !clusterFeatures.isEmpty()) {
+                    boolean featuresInitialized = synchronizers.containsKey(Constants.FEATURES_MAP + Configurations.SEPARATOR + groupName);
                     // get the features from the cluster group and update locally
                     for (FeatureState state : clusterFeatures.values()) {
                         String name = state.getName();
@@ -189,7 +190,7 @@ public class FeaturesSynchronizer extends FeaturesSupport implements Synchronize
                                 }
                             }
                             // if feature has to be uninstalled locally (and node is not the first one in the cluster group)
-                            if (clusterManager.listNodesByGroup(group).size() > 1 && !clusterInstalled && locallyInstalled) {
+                            if (featuresInitialized && !clusterInstalled && locallyInstalled) {
                                 try {
                                     LOGGER.debug("CELLAR FEATURE: uninstalling feature {}/{}", state.getName(), state.getVersion());
                                     featuresService.uninstallFeature(state.getName(), state.getVersion());
@@ -229,7 +230,7 @@ public class FeaturesSynchronizer extends FeaturesSupport implements Synchronize
 
                 Map<String, String> clusterRepositories = clusterManager.getMap(Constants.REPOSITORIES_MAP + Configurations.SEPARATOR + groupName);
                 Map<String, FeatureState> clusterFeatures = clusterManager.getMap(Constants.FEATURES_MAP + Configurations.SEPARATOR + groupName);
-                Map<String, Boolean> synchronizers = clusterManager.getMap("org.apache.karaf.cellar.bundle.synchronizers");
+                Map<String, Boolean> synchronizers = getSynchronizerMap();
 
                 Repository[] repositoryList = new Repository[0];
                 Feature[] featuresList = new Feature[0];
@@ -316,6 +317,7 @@ public class FeaturesSynchronizer extends FeaturesSupport implements Synchronize
                         }
                     }
                 }
+                synchronizers.put(Constants.FEATURES_MAP + Configurations.SEPARATOR + groupName, true);
             } finally {
                 Thread.currentThread().setContextClassLoader(originalClassLoader);
             }

--- a/features/src/main/java/org/apache/karaf/cellar/features/FeaturesSynchronizer.java
+++ b/features/src/main/java/org/apache/karaf/cellar/features/FeaturesSynchronizer.java
@@ -19,6 +19,7 @@ import org.apache.karaf.cellar.core.Synchronizer;
 import org.apache.karaf.cellar.core.control.SwitchStatus;
 import org.apache.karaf.cellar.core.event.EventProducer;
 import org.apache.karaf.cellar.core.event.EventType;
+import org.apache.karaf.cellar.core.utils.CellarUtils;
 import org.apache.karaf.features.*;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.cm.Configuration;
@@ -163,7 +164,7 @@ public class FeaturesSynchronizer extends FeaturesSupport implements Synchronize
                 }
 
                 if (clusterFeatures != null && !clusterFeatures.isEmpty()) {
-                    boolean featuresInitialized = synchronizers.containsKey(Constants.FEATURES_MAP + Configurations.SEPARATOR + groupName);
+                    boolean doUninstallFeaturesNotPresentInCluster = CellarUtils.doCleanupResourcesNotPresentInCluster(configurationAdmin) && synchronizers.containsKey(Constants.FEATURES_MAP + Configurations.SEPARATOR + groupName);
                     // get the features from the cluster group and update locally
                     for (FeatureState state : clusterFeatures.values()) {
                         String name = state.getName();
@@ -190,7 +191,7 @@ public class FeaturesSynchronizer extends FeaturesSupport implements Synchronize
                                 }
                             }
                             // if feature has to be uninstalled locally (and node is not the first one in the cluster group)
-                            if (featuresInitialized && !clusterInstalled && locallyInstalled) {
+                            if (doUninstallFeaturesNotPresentInCluster && !clusterInstalled && locallyInstalled) {
                                 try {
                                     LOGGER.debug("CELLAR FEATURE: uninstalling feature {}/{}", state.getName(), state.getVersion());
                                     featuresService.uninstallFeature(state.getName(), state.getVersion());


### PR DESCRIPTION
Use a dedicated map to keep track of the fact that a specific synchronizer has already been started on the cluster, instead of just checking if you're not the first node.
Also added a configuration property in node.cfg 
 : org.apache.karaf.cellar.cleanupResourcesNotPresentInCluster that allow to prevent removal of resources not present in cluster

