### PR TITLE
Single thread executor

### DIFF
--- a/core/src/main/java/org/apache/karaf/cellar/core/event/EventHandlerRegistryDispatcher.java
+++ b/core/src/main/java/org/apache/karaf/cellar/core/event/EventHandlerRegistryDispatcher.java
@@ -16,17 +16,27 @@ package org.apache.karaf.cellar.core.event;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Event handler service registry dispatcher.
  */
 public class EventHandlerRegistryDispatcher<E extends Event> implements EventDispatcher<E> {
 
+    private static final transient Logger LOGGER = LoggerFactory.getLogger(EventHandlerRegistryDispatcher.class);
     private ExecutorService threadPool;
     private EventHandlerRegistry handlerRegistry;
 
     public void init() {
         if (threadPool == null) {
-            threadPool = Executors.newCachedThreadPool();
+            if (Boolean.getBoolean(this.getClass().getName() + ".threadPool.singleThreadExecutor")) {
+                LOGGER.info("Will use an Executor that uses a single worker thread");
+                threadPool = Executors.newSingleThreadExecutor();
+            } else {
+                LOGGER.info("Will use an Executor with a pool of threads");
+                threadPool = Executors.newCachedThreadPool();
+            }
         }
     }
 

--- a/core/src/main/java/org/apache/karaf/cellar/core/event/EventHandlerRegistryDispatcher.java
+++ b/core/src/main/java/org/apache/karaf/cellar/core/event/EventHandlerRegistryDispatcher.java
@@ -66,4 +66,10 @@ public class EventHandlerRegistryDispatcher<E extends Event> implements EventDis
         this.threadPool = threadPool;
     }
 
+    public void destroy() {
+        if (threadPool != null) {
+            threadPool.shutdown();
+        }
+    }
+
 }

--- a/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/internal/osgi/Activator.java
+++ b/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/internal/osgi/Activator.java
@@ -98,6 +98,8 @@ public class Activator extends BaseActivator implements ManagedService {
 
     private HashMap updatedConfig;
 
+    private EventHandlerRegistryDispatcher dispatcher;
+
     @Override
     public void doStart() throws Exception {
 
@@ -144,7 +146,7 @@ public class Activator extends BaseActivator implements ManagedService {
         extender.init();
 
         LOGGER.debug("CELLAR HAZELCAST: init dispatcher");
-        EventHandlerRegistryDispatcher dispatcher = new EventHandlerRegistryDispatcher();
+        dispatcher = new EventHandlerRegistryDispatcher();
         dispatcher.setHandlerRegistry(eventHandlerRegistry);
         dispatcher.init();
 
@@ -401,6 +403,10 @@ public class Activator extends BaseActivator implements ManagedService {
         if (combinedClassLoader != null) {
             combinedClassLoader.destroy();
             combinedClassLoader = null;
+        }
+        if (dispatcher != null) {
+            dispatcher.destroy();
+            dispatcher = null;
         }
     }
 


### PR DESCRIPTION
Allow to use a Single thread executor by passing org.apache.karaf.cellar.core.event.EventHandlerRegistryDispatcher.threadPool.singleThreadExecutor system property. Shutdown executor when bundle is stopped.