### PR TITLE
Hazelcast discovery fix

### DIFF
--- a/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/factory/HazelcastConfigurationManager.java
+++ b/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/factory/HazelcastConfigurationManager.java
@@ -34,7 +34,7 @@ import org.apache.karaf.cellar.core.discovery.DiscoveryService;
  */
 public class HazelcastConfigurationManager {
 
-    private static final transient Logger LOGGER = LoggerFactory.getLogger(HazelcastServiceFactory.class);
+    static final transient Logger LOGGER = LoggerFactory.getLogger(HazelcastServiceFactory.class);
 
     private String xmlConfigLocation = System.getProperty("karaf.etc") + File.separator + "hazelcast.xml";
 
@@ -92,6 +92,10 @@ public class HazelcastConfigurationManager {
     
     public void setDiscoveryServices(List<DiscoveryService> discoveryServices) {
         this.discoveryServices = discoveryServices;
+    }
+
+    protected Set<String> getDiscoveredMemberSet() {
+        return discoveredMemberSet;
     }
 
 }

--- a/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/factory/HazelcastServiceFactory.java
+++ b/hazelcast/src/main/java/org/apache/karaf/cellar/hazelcast/factory/HazelcastServiceFactory.java
@@ -13,6 +13,7 @@
  */
 package org.apache.karaf.cellar.hazelcast.factory;
 
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
@@ -48,7 +49,12 @@ public class HazelcastServiceFactory {
     }
 
     public void update(Map properties) throws InterruptedException {
-        configurationManager.isUpdated(properties);
+        if (configurationManager.isUpdated(properties) && instance != null) {
+            // updating the member list
+            HazelcastConfigurationManager.LOGGER.info("Updating the member list to: {}", configurationManager.getDiscoveredMemberSet());
+            instance.getConfig().getNetworkConfig().getJoin().getTcpIpConfig()
+                    .setMembers(new LinkedList<String>(configurationManager.getDiscoveredMemberSet()));
+        }
     }
 
     /**


### PR DESCRIPTION
When the discovery service detects membership changes, it it now reflecting those changes in the Hazelcast TcpIpConfig. This solves the cluster split and join issue in case of "equal" sub-clusters (same number of nodes in sub-clusters)