### PR TITLE
Modified HazelcastConfigurationManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 .settings
 .idea
 *.i??
+/.metadata/


### PR DESCRIPTION
Hi,
I'm not sure if I'm wrong and I've misunderstood the flow, but I was experiencing a situation in which there is an error. I have more replicas of the same pod on Kubernetes, each containing an Apache Karaf instance using Hazelcast by hazelcast.xml configuration file. I've installed the features cellar-hazelcast and cellar-kubernetes. I was trying to create a Hazelcast cluster using these replicas. At the beginning each replica sees the other, so they form a cluster and share the cache, but when I kill one replica and another replica starts, the mechanism doesn't work well. The KubernetesDiscoverService sees the new ip, but it doesn't join to the Hazelcast cluster. I was thinking the problem may be in the updated method inside the HazelcastConfigurationManager class, which is invoked when there is a new element. Checking the log I've discovered this method is invoked when a replica dies and new replica starts, but the new discoveredMembers aren't added to the hazelcast cluster by tcpip join.
Thanks