### PR TITLE
Remove unused dependencies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -54,6 +54,36 @@
         <dependency>
             <groupId>org.apache.karaf.features</groupId>
             <artifactId>org.apache.karaf.features.core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>txw2</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.istack</groupId>
+                    <artifactId>istack-commons-runtime</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.xml.fastinfoset</groupId>
+                    <artifactId>FastInfoset</artifactId>
+                </exclusion> 
+                <exclusion>
+                    <groupId>jakarta.activation</groupId>
+                    <artifactId>jakarta.activation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ops4j.base</groupId>
+                    <artifactId>ops4j-base-util-collections</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf</groupId>


### PR DESCRIPTION
@jbonofre Hi, I am a user of project **_org.apache.karaf.cellar:org.apache.karaf.cellar.core:4.2.2-SNAPSHOT_**. I found that its pom file introduced **_31_** dependencies. However, among them, **_8_** libraries (**_25%_**) have not been used by your project (the redundant dependencies are listed below). This PR helps **_org.apache.karaf.cellar:org.apache.karaf.cellar.core:4.2.2-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.ops4j.base:ops4j-base-util-collections:jar:1.5.1:compile
jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.2:compile
jakarta.activation:jakarta.activation-api:jar:1.2.1:compile
org.glassfish.jaxb:jaxb-runtime:jar:2.3.2:compile
org.glassfish.jaxb:txw2:jar:2.3.2:compile
com.sun.istack:istack-commons-runtime:jar:3.0.8:compile
org.jvnet.staxex:stax-ex:jar:1.8.1:compile
com.sun.xml.fastinfoset:FastInfoset:jar:1.2.16:compile
</code></pre>