### PR TITLE
[KARAF-7515] Return CancellationException from RemoteServiceInvocationHandler

### DIFF
--- a/dosgi/src/main/java/org/apache/karaf/cellar/dosgi/RemoteServiceInvocationHandler.java
+++ b/dosgi/src/main/java/org/apache/karaf/cellar/dosgi/RemoteServiceInvocationHandler.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Method;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
 
 /**
  * Handler for cluster remote service invocation event.
@@ -75,7 +76,7 @@ public class RemoteServiceInvocationHandler implements InvocationHandler {
                 return result.getResult();
             }
         }
-        return null;
+        throw new CancellationException(String.format("No remote service execution results for %s", serviceClass));
     }
 
 }

--- a/dosgi/src/main/java/org/apache/karaf/cellar/dosgi/shell/ListDistributedServicesCommand.java
+++ b/dosgi/src/main/java/org/apache/karaf/cellar/dosgi/shell/ListDistributedServicesCommand.java
@@ -48,7 +48,6 @@ public class ListDistributedServicesCommand extends CellarCommandSupport {
                             nodeName = node.getId();
                         }
                         table.addRow().addContent(serviceClass, nodeName);
-                        serviceClass = "";
                     }
                 }
                 table.print(System.out);


### PR DESCRIPTION
instead of null to differentiate between null result from remote service and a timeout on a remote call.

Removed service class String reset to prevent listing of multiple remote services without denominator.